### PR TITLE
Add duplicate group memberships synchronization

### DIFF
--- a/app/controllers/decidim/civicrm/admin/groups_controller.rb
+++ b/app/controllers/decidim/civicrm/admin/groups_controller.rb
@@ -31,6 +31,12 @@ module Decidim
           end
         end
 
+        def sync_duplicate_memberships
+          SyncDuplicateGroupMembershipsJob.perform_later
+          flash[:notice] = t("success", scope: "decidim.civicrm.admin.groups.sync_duplicate_memberships")
+          redirect_back fallback_location: decidim_civicrm_admin.groups_path
+        end
+
         def toggle_auto_sync
           return if group.blank?
 

--- a/app/jobs/decidim/civicrm/sync_all_groups_job.rb
+++ b/app/jobs/decidim/civicrm/sync_all_groups_job.rb
@@ -34,6 +34,10 @@ module Decidim
           Rails.logger.info "SyncAllGroupsJob: #{Group.where(marked_for_deletion: sync_id).count} groups to delete"
 
           Group.clean_up_records({ decidim_organization_id: organization_id }, sync_id: sync_id)
+
+          # Sync duplicate memberships after all groups are synced
+          Rails.logger.info "SyncAllGroupsJob: Scheduling duplicate memberships sync"
+          SyncDuplicateGroupMembershipsJob.perform_later
         end
       end
 
@@ -59,7 +63,7 @@ module Decidim
           Rails.logger.info "SyncAllGroupsJob: Auto sync enabled for group #{group.id}, updating members..."
           # Sleep before starting member sync to avoid hitting API rate limits
           sleep(Decidim::Civicrm.api_rate_limit_delay)
-          SyncGroupMembersJob.perform_now(group.id)
+          SyncGroupMembersJob.perform_now(group.id, skip_duplicate_sync: true)
         else
           Rails.logger.info "SyncAllGroupsJob: Auto sync disabled for group #{group.id}, skipping member sync"
         end

--- a/app/jobs/decidim/civicrm/sync_duplicate_group_memberships_job.rb
+++ b/app/jobs/decidim/civicrm/sync_duplicate_group_memberships_job.rb
@@ -10,16 +10,17 @@ module Decidim
       def perform
         Rails.logger.info "SyncDuplicateGroupMembershipsJob: Starting synchronization"
 
-        # Find all civicrm_contact_ids that have multiple group memberships
+        # Find all civicrm_contact_ids that have multiple group memberships within the same organization
         duplicate_contacts = GroupMembership
-                             .group(:civicrm_contact_id)
+                             .joins(:group)
+                             .group(:civicrm_contact_id, "decidim_civicrm_groups.decidim_organization_id")
                              .having("COUNT(*) > 1")
-                             .pluck(:civicrm_contact_id)
+                             .pluck(:civicrm_contact_id, "decidim_civicrm_groups.decidim_organization_id")
 
         Rails.logger.info "SyncDuplicateGroupMembershipsJob: Found #{duplicate_contacts.count} contacts with duplicate memberships"
 
-        duplicate_contacts.each do |civicrm_contact_id|
-          sync_contact_memberships(civicrm_contact_id)
+        duplicate_contacts.each do |civicrm_contact_id, organization_id|
+          sync_contact_memberships(civicrm_contact_id, organization_id)
         end
 
         Rails.logger.info "SyncDuplicateGroupMembershipsJob: Synchronization completed"
@@ -27,10 +28,11 @@ module Decidim
 
       private
 
-      def sync_contact_memberships(civicrm_contact_id)
+      def sync_contact_memberships(civicrm_contact_id, organization_id)
         memberships = GroupMembership
-                      .where(civicrm_contact_id: civicrm_contact_id)
-                      .order(updated_at: :desc)
+                      .joins(:group)
+                      .where(civicrm_contact_id: civicrm_contact_id, decidim_civicrm_groups: { decidim_organization_id: organization_id })
+                      .order(updated_at: :desc, id: :desc)
 
         return if memberships.count <= 1
 
@@ -47,8 +49,10 @@ module Decidim
 
       def sync_membership_data(target, source)
         # Update fields from the source membership
+        target.contact_id = source.contact_id
         target.extra = source.extra if source.extra.present?
         target.custom_fields = source.custom_fields if source.custom_fields.present?
+        target.marked_for_deletion = source.marked_for_deletion
 
         if target.changed?
           target.save!

--- a/app/jobs/decidim/civicrm/sync_duplicate_group_memberships_job.rb
+++ b/app/jobs/decidim/civicrm/sync_duplicate_group_memberships_job.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Civicrm
+    # Job to synchronize data between group memberships that share the same civicrm_contact_id
+    # Keeps data from the most recently updated record
+    class SyncDuplicateGroupMembershipsJob < ApplicationJob
+      queue_as :default
+
+      def perform
+        Rails.logger.info "SyncDuplicateGroupMembershipsJob: Starting synchronization"
+
+        # Find all civicrm_contact_ids that have multiple group memberships
+        duplicate_contacts = GroupMembership
+                             .group(:civicrm_contact_id)
+                             .having("COUNT(*) > 1")
+                             .pluck(:civicrm_contact_id)
+
+        Rails.logger.info "SyncDuplicateGroupMembershipsJob: Found #{duplicate_contacts.count} contacts with duplicate memberships"
+
+        duplicate_contacts.each do |civicrm_contact_id|
+          sync_contact_memberships(civicrm_contact_id)
+        end
+
+        Rails.logger.info "SyncDuplicateGroupMembershipsJob: Synchronization completed"
+      end
+
+      private
+
+      def sync_contact_memberships(civicrm_contact_id)
+        memberships = GroupMembership
+                      .where(civicrm_contact_id: civicrm_contact_id)
+                      .order(updated_at: :desc)
+
+        return if memberships.count <= 1
+
+        # The most recently updated membership is the source of truth
+        source_membership = memberships.first
+
+        Rails.logger.info "SyncDuplicateGroupMembershipsJob: Syncing #{memberships.count} memberships for contact #{civicrm_contact_id}"
+
+        # Update all other memberships to match the source
+        memberships.offset(1).each do |membership|
+          sync_membership_data(membership, source_membership)
+        end
+      end
+
+      def sync_membership_data(target, source)
+        # Update fields from the source membership
+        target.extra = source.extra if source.extra.present?
+        target.custom_fields = source.custom_fields if source.custom_fields.present?
+
+        if target.changed?
+          target.save!
+          Rails.logger.info "SyncDuplicateGroupMembershipsJob: Updated membership #{target.id} (group: #{target.group_id}) from membership #{source.id}"
+        else
+          Rails.logger.debug { "SyncDuplicateGroupMembershipsJob: No changes needed for membership #{target.id}" }
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/decidim/civicrm/sync_duplicate_group_memberships_job.rb
+++ b/app/jobs/decidim/civicrm/sync_duplicate_group_memberships_job.rb
@@ -10,16 +10,17 @@ module Decidim
       def perform
         Rails.logger.info "SyncDuplicateGroupMembershipsJob: Starting synchronization"
 
-        # Find all civicrm_contact_ids that have multiple group memberships
+        # Find all civicrm_contact_ids that have multiple group memberships within the same organization
         duplicate_contacts = GroupMembership
-                             .group(:civicrm_contact_id)
+                             .joins(:group)
+                             .group(:civicrm_contact_id, "decidim_civicrm_groups.decidim_organization_id")
                              .having("COUNT(*) > 1")
-                             .pluck(:civicrm_contact_id)
+                             .pluck(:civicrm_contact_id, "decidim_civicrm_groups.decidim_organization_id")
 
         Rails.logger.info "SyncDuplicateGroupMembershipsJob: Found #{duplicate_contacts.count} contacts with duplicate memberships"
 
-        duplicate_contacts.each do |civicrm_contact_id|
-          sync_contact_memberships(civicrm_contact_id)
+        duplicate_contacts.each do |civicrm_contact_id, organization_id|
+          sync_contact_memberships(civicrm_contact_id, organization_id)
         end
 
         Rails.logger.info "SyncDuplicateGroupMembershipsJob: Synchronization completed"
@@ -27,10 +28,11 @@ module Decidim
 
       private
 
-      def sync_contact_memberships(civicrm_contact_id)
+      def sync_contact_memberships(civicrm_contact_id, organization_id)
         memberships = GroupMembership
-                      .where(civicrm_contact_id: civicrm_contact_id)
-                      .order(updated_at: :desc)
+                      .joins(:group)
+                      .where(civicrm_contact_id: civicrm_contact_id, decidim_civicrm_groups: { decidim_organization_id: organization_id })
+                      .order(updated_at: :desc, id: :desc)
 
         return if memberships.count <= 1
 

--- a/app/jobs/decidim/civicrm/sync_duplicate_group_memberships_job.rb
+++ b/app/jobs/decidim/civicrm/sync_duplicate_group_memberships_job.rb
@@ -49,10 +49,8 @@ module Decidim
 
       def sync_membership_data(target, source)
         # Update fields from the source membership
-        target.contact_id = source.contact_id
         target.extra = source.extra if source.extra.present?
         target.custom_fields = source.custom_fields if source.custom_fields.present?
-        target.marked_for_deletion = source.marked_for_deletion
 
         if target.changed?
           target.save!

--- a/app/jobs/decidim/civicrm/sync_group_members_job.rb
+++ b/app/jobs/decidim/civicrm/sync_group_members_job.rb
@@ -7,6 +7,7 @@ module Decidim
 
       def perform(group_id, page: 0, sync_id: nil, skip_duplicate_sync: false)
         sync_id ||= Time.current # Generate a sync ID if not provided
+        @skip_duplicate_sync = skip_duplicate_sync
 
         group = Decidim::Civicrm::Group.find(group_id)
 
@@ -22,7 +23,6 @@ module Decidim
 
           update_group(group, data[:group])
           GroupMembership.prepare_cleanup({ group_id: group_id }, sync_id: sync_id) if page.zero?
-          @skip_duplicate_sync = skip_duplicate_sync
         end
 
         update_group_memberships(group, page:, sync_id:)

--- a/app/jobs/decidim/civicrm/sync_group_members_job.rb
+++ b/app/jobs/decidim/civicrm/sync_group_members_job.rb
@@ -5,7 +5,7 @@ module Decidim
     class SyncGroupMembersJob < ApplicationJob
       queue_as :default
 
-      def perform(group_id, page: 0, sync_id: nil)
+      def perform(group_id, page: 0, sync_id: nil, skip_duplicate_sync: false)
         sync_id ||= Time.current # Generate a sync ID if not provided
 
         group = Decidim::Civicrm::Group.find(group_id)
@@ -22,6 +22,7 @@ module Decidim
 
           update_group(group, data[:group])
           GroupMembership.prepare_cleanup({ group_id: group_id }, sync_id: sync_id) if page.zero?
+          @skip_duplicate_sync = skip_duplicate_sync
         end
 
         update_group_memberships(group, page:, sync_id:)
@@ -67,13 +68,19 @@ module Decidim
 
         if has_more_pages
           Rails.logger.info "SyncGroupMembersJob: Scheduling page #{page + 1} in #{Decidim::Civicrm.api_rate_limit_delay} seconds"
-          SyncGroupMembersJob.set(wait: Decidim::Civicrm.api_rate_limit_delay).perform_later(group.id, page: page + 1, sync_id: sync_id)
+          SyncGroupMembersJob.set(wait: Decidim::Civicrm.api_rate_limit_delay).perform_later(group.id, page: page + 1, sync_id: sync_id, skip_duplicate_sync: @skip_duplicate_sync)
         else
           Rails.logger.info "SyncGroupMembersJob: #{GroupMembership.where(group_id: group.id, marked_for_deletion: sync_id).count} group memberships to delete"
 
           GroupMembership.clean_up_records({ group_id: group.id }, sync_id: sync_id)
 
           ActiveSupport::Notifications.publish("decidim.civicrm.group_membership.updated", group.id)
+
+          # Sync duplicate memberships only if not called from SyncAllGroupsJob
+          unless @skip_duplicate_sync
+            Rails.logger.info "SyncGroupMembersJob: Scheduling duplicate memberships sync"
+            SyncDuplicateGroupMembershipsJob.perform_later
+          end
         end
       end
     end

--- a/app/views/decidim/civicrm/admin/group_members/index.html.erb
+++ b/app/views/decidim/civicrm/admin/group_members/index.html.erb
@@ -3,7 +3,7 @@
     <h2 class="item_show__header-title">
       <%= t(".title", group_name: group.title) %>
 
-      <%= link_to t(".sync"), decidim_civicrm_admin.sync_groups_path(id: group.id), class: "button button__sm button__secondary" %>
+      <%= link_to t(".sync"), decidim_civicrm_admin.sync_groups_path(id: group.id), method: :post, class: "button button__sm button__secondary" %>
     </h2>
   </div>
 
@@ -73,7 +73,7 @@
                   <% end %>
                   <%= icon_link_to "mail-line", current_or_new_conversation_path_with(member.user), t(".contact"), class:"action-icon--new" %>
                 <% end %>
-                <%= icon_link_to "refresh-line", decidim_civicrm_admin.sync_group_group_members_path(id: member.id), t(".sync"), class: "action-icon--reload" %>
+                <%= icon_link_to "refresh-line", decidim_civicrm_admin.sync_group_group_members_path(id: member.id), t(".sync"), method: :post, class: "action-icon--reload" %>
               </td>
             </tr>
           <% end %>
@@ -83,7 +83,7 @@
     <% elsif all_memberships.empty? %>
       <p class="callout warning mt-4">
         <%= t(".empty") %>
-        <%= link_to t(".sync"), decidim_civicrm_admin.sync_groups_path(id: group.id) %>
+        <%= link_to t(".sync"), decidim_civicrm_admin.sync_groups_path(id: group.id), method: :post %>
       </p>
     <% end %>
   </div>

--- a/app/views/decidim/civicrm/admin/groups/index.html.erb
+++ b/app/views/decidim/civicrm/admin/groups/index.html.erb
@@ -3,7 +3,8 @@
     <h2 class="item_show__header-title">
       <%= t(".title") %>
 
-      <%= link_to t(".sync"), decidim_civicrm_admin.sync_groups_path, class: "button button__sm button__secondary" %>
+      <%= link_to t(".sync"), decidim_civicrm_admin.sync_groups_path, method: :post, class: "button button__sm button__secondary" %>
+      <%= link_to t(".sync_duplicate_memberships"), decidim_civicrm_admin.sync_duplicate_memberships_groups_path, method: :post, class: "button button__sm button__transparent-secondary" %>
     </h2>
   </div>
 
@@ -15,10 +16,10 @@
         <thead>
           <tr>
             <th><%= sort_link(query, :civicrm_group_id, t(".civicrm_id"), default_order: :desc) %></th>
-            <th><%= sort_link(query, :name, t(".name"), default_order: :desc) %></th>
+            <th><%= sort_link(query, :title, t(".name"), default_order: :desc) %></th>
             <th><%= sort_link(query, :status, t(".status")) %></th>
             <th><%= t(".registered") %></th>
-            <th><%= t(".members_civicrm") %></th>
+            <th><%= sort_link(query, :civicrm_member_count, t(".members_civicrm"), default_order: :desc) %></th>
             <th><%= t(".memberships") %></th>
             <th><%= t(".with_custom_fields") %></th>
             <th><%= sort_link(query, :updated_at, t(".last_sync"), default_order: :desc) %></th>
@@ -41,12 +42,12 @@
               <td class="<%= last_sync_class(group) %>"><%= l(group.last_sync, format: :decidim_short) if group.last_sync %></td>
               <td class="table-list__actions">
               <% if group.auto_sync_members? %>
-                <%= icon_link_to "stop-circle-line", decidim_civicrm_admin.toggle_auto_sync_groups_path(id: group.id), t(".auto_sync.disable"), class: "action-icon action-icon--success", method: :put %>
+                <%= icon_link_to "stop-circle-line", decidim_civicrm_admin.toggle_auto_sync_groups_path(id: group.id), t(".auto_sync.disable"), class: "action-icon action-icon--success", method: :post %>
               <% else %>
-                <%= icon_link_to "play-circle-line", decidim_civicrm_admin.toggle_auto_sync_groups_path(id: group.id), t(".auto_sync.enable"), class: "action-icon action-icon--remove", method: :put %>
+                <%= icon_link_to "play-circle-line", decidim_civicrm_admin.toggle_auto_sync_groups_path(id: group.id), t(".auto_sync.enable"), class: "action-icon action-icon--remove", method: :post %>
               <% end %>
 
-              <%= icon_link_to "refresh-line", decidim_civicrm_admin.sync_groups_path(id: group.id), t(".sync"), class: "action-icon--reload" %>
+              <%= icon_link_to "refresh-line", decidim_civicrm_admin.sync_groups_path(id: group.id), t(".sync"), method: :post, class: "action-icon--reload" %>
               <%= icon_link_to "group-line", decidim_civicrm_admin.group_group_members_path(group), t(".members"), class: "action-icon" %>
               </td>
             </tr>
@@ -57,7 +58,7 @@
     <% elsif all_groups.empty? %>
       <p class="callout warning mt-4">
         <%= t(".empty") %>
-        <%= link_to t(".sync"), decidim_civicrm_admin.sync_groups_path %>
+        <%= link_to t(".sync"), decidim_civicrm_admin.sync_groups_path, method: :post %>
       </p>
     <% end %>
   </div>

--- a/app/views/decidim/civicrm/admin/meeting_registrations/index.html.erb
+++ b/app/views/decidim/civicrm/admin/meeting_registrations/index.html.erb
@@ -4,7 +4,7 @@
       <%= t(".title") %>
 
       <%= link_to t(".new"), decidim_civicrm_admin.new_meeting_registration_path, class: "button button__sm button__secondary" %>
-      <%= link_to t(".sync"), decidim_civicrm_admin.sync_meeting_registrations_path, class: "button button__sm button__secondary" %>
+      <%= link_to t(".sync"), decidim_civicrm_admin.sync_meeting_registrations_path, method: :post, class: "button button__sm button__secondary" %>
     </h2>
   </div>
   <div class="table-scroll">
@@ -46,14 +46,14 @@
               <td class="table-list__actions">
               <% if event_meeting.redirect_url.present? %>
                 <% if event_meeting.redirect_active? %>
-                  <%= icon_link_to "check-line", decidim_civicrm_admin.toggle_active_meeting_registrations_path(id: event_meeting.id), t(".redirect_active.disable"), class: "action-icon action-icon--success", method: :put %>
+                  <%= icon_link_to "check-line", decidim_civicrm_admin.toggle_active_meeting_registrations_path(id: event_meeting.id), t(".redirect_active.disable"), class: "action-icon action-icon--success", method: :post %>
                 <% else %>
-                  <%= icon_link_to "check-line", decidim_civicrm_admin.toggle_active_meeting_registrations_path(id: event_meeting.id), t(".redirect_active.enable"), class: "action-icon action-icon--remove", method: :put %>
+                  <%= icon_link_to "check-line", decidim_civicrm_admin.toggle_active_meeting_registrations_path(id: event_meeting.id), t(".redirect_active.enable"), class: "action-icon action-icon--remove", method: :post %>
                 <% end %>
               <% end %>
 
               <%= icon_link_to "pencil", decidim_civicrm_admin.edit_meeting_registration_path(id: event_meeting.id), t(".edit"), class: "action-icon--pencil" %>
-              <%= icon_link_to "refresh-line", decidim_civicrm_admin.sync_meeting_registrations_path(id: event_meeting.id), t(".sync"), class: "action-icon--reload" %>
+              <%= icon_link_to "refresh-line", decidim_civicrm_admin.sync_meeting_registrations_path(id: event_meeting.id), t(".sync"), method: :post, class: "action-icon--reload" %>
               <%= icon_link_to "group-line", decidim_civicrm_admin.meeting_registration_path(event_meeting), t(".registrations"), class: "action-icon" %>
 
               <% unless event_meeting.civicrm_event_id.present? %>

--- a/app/views/decidim/civicrm/admin/meeting_registrations/show.html.erb
+++ b/app/views/decidim/civicrm/admin/meeting_registrations/show.html.erb
@@ -6,7 +6,7 @@
         <%= icon "external-link-line" %>
       <% end %>
 
-      <%= link_to t(".sync"), decidim_civicrm_admin.sync_meeting_registrations_path(id: event_meeting.id), class: "button button__sm button__secondary" %>
+      <%= link_to t(".sync"), decidim_civicrm_admin.sync_meeting_registrations_path(id: event_meeting.id), method: :post, class: "button button__sm button__secondary" %>
     </h2>
   </div>
 
@@ -59,7 +59,7 @@
     <% else %>
       <p class="callout warning">
         <%= t(".empty") %>
-        <%= link_to t(".sync"), decidim_civicrm_admin.sync_meeting_registrations_path(id: event_meeting.id) %>
+        <%= link_to t(".sync"), decidim_civicrm_admin.sync_meeting_registrations_path(id: event_meeting.id), method: :post %>
       </p>
     <% end %>
   </div>

--- a/app/views/decidim/civicrm/admin/meetings/index.html.erb
+++ b/app/views/decidim/civicrm/admin/meetings/index.html.erb
@@ -3,7 +3,7 @@
     <h2 class="item_show__header-title">
       <%= t(".meetings_title") %>
 
-      <%= link_to t(".sync"), decidim_civicrm_admin.sync_meetings_path, class: "button button__sm button__secondary" %>
+      <%= link_to t(".sync"), decidim_civicrm_admin.sync_meetings_path, method: :post, class: "button button__sm button__secondary" %>
     </h2>
   </div>
   <div class="table-scroll">

--- a/app/views/decidim/civicrm/admin/membership_types/index.html.erb
+++ b/app/views/decidim/civicrm/admin/membership_types/index.html.erb
@@ -3,7 +3,7 @@
     <h2 class="item_show__header-title">
       <%= t(".title") %>
 
-      <%= link_to t(".sync"), decidim_civicrm_admin.sync_membership_types_path, class: "button button__sm button__secondary" %>
+      <%= link_to t(".sync"), decidim_civicrm_admin.sync_membership_types_path, method: :post, class: "button button__sm button__secondary" %>
     </h2>
   </div>
   <div class="table-scroll">
@@ -32,7 +32,7 @@
     <% else %>
       <div class="callout warning mt-4">
         <%= t(".empty") %>
-        <%= link_to t(".sync"), decidim_civicrm_admin.sync_membership_types_path %>
+        <%= link_to t(".sync"), decidim_civicrm_admin.sync_membership_types_path, method: :post %>
       </div>
     <% end %>
   </div>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -76,6 +76,7 @@ ca:
             name: Nom
             registered: Registrats a Decidim
             sync: Sincronitzar-ho tot amb CiViCRM
+            sync_duplicate_memberships: Sincronitza membres duplicats
             title: Grups
             members_civicrm: Membres al CiViCRM
             memberships: Membres a Decidim
@@ -83,6 +84,8 @@ ca:
             status: Estat
           sync:
             success: La sincronització ha començat
+          sync_duplicate_memberships:
+            success: La sincronització de membres duplicats ha començat
           participatory_spaces:
             save: Desa els canvis
             sync_members: 'Sincronitza aquests membres com a participants privats dels espais participatius:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -91,6 +91,7 @@ en:
             registered: Registered in Decidim
             status: Status
             sync: Synchronize all with CiViCRM
+            sync_duplicate_memberships: Sync duplicate memberships
             title: Groups
             with_custom_fields: With custom fields
           participatory_spaces:
@@ -100,6 +101,8 @@ en:
             title: Participatory spaces synchronization
           sync:
             success: The synchronization has started
+          sync_duplicate_memberships:
+            success: The duplicate memberships synchronization has started
         info:
           create:
             not_a_civicrm_authorization: Not a CiViCRM authorization

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -76,6 +76,7 @@ es:
             name: Nombre
             registered: Registrados en Decidim
             sync: Sincronizarlo todo con CiViCRM
+            sync_duplicate_memberships: Sincronizar membresías duplicadas
             title: Grupos
             members_civicrm: Miembros en CiViCRM
             memberships: Miembros en Decidim
@@ -83,6 +84,8 @@ es:
             status: Estado
           sync:
             success: La sincronización ha empezado
+          sync_duplicate_memberships:
+            success: La sincronización de membresías duplicadas ha empezado
           participatory_spaces:
             save: Guarda los cambios
             sync_members: 'Sincroniza estos miembros como participantes privados de los espacios participativos:'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -76,6 +76,7 @@ fr:
             name: Nom
             registered: Enregistrés dans Decidim
             sync: Tout synchroniser avec CiViCRM
+            sync_duplicate_memberships: Synchroniser les adhésions en double
             title: Groupes
             members_civicrm: Membres dans CiViCRM
             memberships: Membres dans Decidim
@@ -83,6 +84,8 @@ fr:
             status: Statut
           sync:
             success: La synchronisation a commencé
+          sync_duplicate_memberships:
+            success: La synchronisation des adhésions en double a commencé
           participatory_spaces:
             save: Sauvegarder les modifications
             sync_members: 'Synchroniser ces membres en tant que participants privés dans ces espaces participatifs :'

--- a/lib/decidim/civicrm/admin_engine.rb
+++ b/lib/decidim/civicrm/admin_engine.rb
@@ -15,34 +15,35 @@ module Decidim
         resources :info, only: [:index, :create]
         resources :groups, only: [:index, :update] do
           collection do
-            get :sync
+            post :sync
+            post :sync_duplicate_memberships
             get :participatory_spaces
-            put :toggle_auto_sync
+            post :toggle_auto_sync
           end
 
           resources :group_members, only: :index do
             collection do
-              get :sync
+              post :sync
             end
           end
         end
 
         resources :membership_types, only: :index do
           collection do
-            get :sync
+            post :sync
           end
         end
 
         resources :meetings, only: :index do
           collection do
-            get :sync
+            post :sync
           end
         end
 
         resources :meeting_registrations do
           collection do
-            get :sync
-            put :toggle_active
+            post :sync
+            post :toggle_active
           end
         end
 

--- a/lib/tasks/civicrm.rake
+++ b/lib/tasks/civicrm.rake
@@ -10,5 +10,10 @@ namespace :civicrm do
         Decidim::Civicrm::SyncAllGroupsJob.perform_now(organization.id)
       end
     end
+
+    desc "Synchronize data between group memberships that share the same civicrm_contact_id"
+    task duplicate_memberships: :environment do
+      Decidim::Civicrm::SyncDuplicateGroupMembershipsJob.perform_now
+    end
   end
 end

--- a/spec/jobs/sync_all_groups_job_spec.rb
+++ b/spec/jobs/sync_all_groups_job_spec.rb
@@ -17,6 +17,11 @@ module Decidim::Civicrm
       expect(Group.pluck(:civicrm_group_id)).to contain_exactly(1, 2)
     end
 
+    it "schedules duplicate memberships sync job after all groups are synced" do
+      subject.perform_now(organization.id)
+      expect(SyncDuplicateGroupMembershipsJob).to have_been_enqueued
+    end
+
     context "when there are groups to delete" do
       let!(:group) { create(:civicrm_group, organization:, civicrm_group_id: 3) }
 
@@ -97,6 +102,7 @@ module Decidim::Civicrm
         expect { subject.perform_now(organization.id, page: 0) }.to change(Group, :count).by(1)
         expect(Group.pluck(:civicrm_group_id)).to contain_exactly(1)
         expect(subject).to have_been_enqueued.with(organization.id, page: 1, sync_id: a_kind_of(ActiveSupport::TimeWithZone)).on_queue("default")
+        expect(SyncDuplicateGroupMembershipsJob).not_to have_been_enqueued
       end
 
       describe "with page 1" do
@@ -133,6 +139,7 @@ module Decidim::Civicrm
           create(:civicrm_group, organization:, civicrm_group_id: 1)
           expect { subject.perform_now(organization.id, page: 1) }.to change(Group, :count).by(1)
           expect(Group.pluck(:civicrm_group_id)).to contain_exactly(1, 2)
+          expect(SyncDuplicateGroupMembershipsJob).to have_been_enqueued
         end
       end
     end

--- a/spec/jobs/sync_duplicate_group_memberships_job_spec.rb
+++ b/spec/jobs/sync_duplicate_group_memberships_job_spec.rb
@@ -54,7 +54,6 @@ module Decidim::Civicrm
             subject.perform_now
             older_membership.reload
 
-            expect(older_membership.contact_id).to eq(contact.id)
             expect(older_membership.extra).to eq(extra_data)
             expect(older_membership.custom_fields).to eq(custom_fields_data)
           end
@@ -114,11 +113,9 @@ module Decidim::Civicrm
             oldest_membership.reload
             middle_membership.reload
 
-            expect(oldest_membership.contact_id).to eq(contact.id)
             expect(oldest_membership.extra).to eq(extra_data)
             expect(oldest_membership.custom_fields).to eq(custom_fields_data)
 
-            expect(middle_membership.contact_id).to eq(contact.id)
             expect(middle_membership.extra).to eq(extra_data)
             expect(middle_membership.custom_fields).to eq(custom_fields_data)
           end
@@ -157,11 +154,11 @@ module Decidim::Civicrm
                    updated_at: 1.day.ago)
           end
 
-          it "syncs the marked_for_deletion status" do
+          it "does not sync the marked_for_deletion status" do
             subject.perform_now
             older_membership.reload
 
-            expect(older_membership.marked_for_deletion).not_to be_nil
+            expect(older_membership.marked_for_deletion).to be_nil
           end
         end
 
@@ -191,13 +188,6 @@ module Decidim::Civicrm
 
             expect(older_membership.extra).to eq(old_extra_data)
             expect(older_membership.custom_fields).to eq(old_custom_fields_data)
-          end
-
-          it "still syncs the contact_id" do
-            subject.perform_now
-            older_membership.reload
-
-            expect(older_membership.contact_id).to eq(contact.id)
           end
         end
 
@@ -238,8 +228,9 @@ module Decidim::Civicrm
             membership_set1_old.reload
             membership_set2_old.reload
 
-            expect(membership_set1_old.contact_id).to eq(contact.id)
-            expect(membership_set2_old.contact_id).to eq(contact2.id)
+            # Each old membership should have the extra data from its corresponding newer membership
+            expect(membership_set1_old.extra).to eq(membership_set1_new.extra)
+            expect(membership_set2_old.extra).to eq(membership_set2_new.extra)
           end
         end
 

--- a/spec/jobs/sync_duplicate_group_memberships_job_spec.rb
+++ b/spec/jobs/sync_duplicate_group_memberships_job_spec.rb
@@ -1,0 +1,272 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Civicrm
+  describe SyncDuplicateGroupMembershipsJob do
+    subject { described_class }
+
+    let(:organization) { create(:organization) }
+    let(:group1) { create(:civicrm_group, organization:) }
+    let(:group2) { create(:civicrm_group, organization:) }
+    let(:group3) { create(:civicrm_group, organization:) }
+    let(:contact) { create(:civicrm_contact, organization:, civicrm_contact_id: 100) }
+
+    describe "#perform" do
+      context "when there are no duplicate memberships" do
+        let!(:membership1) { create(:civicrm_group_membership, group: group1, contact:, civicrm_contact_id: 100) }
+        let!(:membership2) { create(:civicrm_group_membership, group: group2, contact: nil, civicrm_contact_id: 200) }
+
+        it "does not change any memberships" do
+          expect { subject.perform_now }.not_to(change { GroupMembership.pluck(:id, :updated_at) })
+        end
+      end
+
+      context "when there are duplicate memberships" do
+        let(:extra_data) { { "display_name" => "John Doe", "email" => "john@example.com" } }
+        let(:custom_fields_data) { { "field1" => "value1", "field2" => "value2" } }
+        let(:old_extra_data) { { "display_name" => "Old Name" } }
+        let(:old_custom_fields_data) { { "old_field" => "old_value" } }
+
+        context "with two memberships sharing the same civicrm_contact_id" do
+          let!(:older_membership) do
+            create(:civicrm_group_membership,
+                   group: group1,
+                   contact: nil,
+                   civicrm_contact_id: 100,
+                   extra: old_extra_data,
+                   custom_fields: old_custom_fields_data,
+                   marked_for_deletion: nil,
+                   updated_at: 2.days.ago)
+          end
+          let!(:newer_membership) do
+            create(:civicrm_group_membership,
+                   group: group2,
+                   contact:,
+                   civicrm_contact_id: 100,
+                   extra: extra_data,
+                   custom_fields: custom_fields_data,
+                   marked_for_deletion: nil,
+                   updated_at: 1.day.ago)
+          end
+
+          it "syncs data from the more recently updated membership to the older one" do
+            subject.perform_now
+            older_membership.reload
+
+            expect(older_membership.contact_id).to eq(contact.id)
+            expect(older_membership.extra).to eq(extra_data)
+            expect(older_membership.custom_fields).to eq(custom_fields_data)
+          end
+
+          it "does not change the newer membership" do
+            newer_values = {
+              contact_id: newer_membership.contact_id,
+              extra: newer_membership.extra,
+              custom_fields: newer_membership.custom_fields
+            }
+
+            subject.perform_now
+            newer_membership.reload
+
+            expect(newer_membership.contact_id).to eq(newer_values[:contact_id])
+            expect(newer_membership.extra).to eq(newer_values[:extra])
+            expect(newer_membership.custom_fields).to eq(newer_values[:custom_fields])
+          end
+
+          it "updates the updated_at timestamp of the older membership" do
+            expect { subject.perform_now }.to(change { older_membership.reload.updated_at })
+          end
+        end
+
+        context "with three memberships sharing the same civicrm_contact_id" do
+          let!(:oldest_membership) do
+            create(:civicrm_group_membership,
+                   group: group1,
+                   contact: nil,
+                   civicrm_contact_id: 100,
+                   extra: {},
+                   custom_fields: {},
+                   updated_at: 3.days.ago)
+          end
+          let!(:middle_membership) do
+            create(:civicrm_group_membership,
+                   group: group2,
+                   contact: nil,
+                   civicrm_contact_id: 100,
+                   extra: old_extra_data,
+                   custom_fields: old_custom_fields_data,
+                   updated_at: 2.days.ago)
+          end
+          let!(:newest_membership) do
+            create(:civicrm_group_membership,
+                   group: group3,
+                   contact:,
+                   civicrm_contact_id: 100,
+                   extra: extra_data,
+                   custom_fields: custom_fields_data,
+                   updated_at: 1.day.ago)
+          end
+
+          it "syncs data from the most recently updated membership to all others" do
+            subject.perform_now
+
+            oldest_membership.reload
+            middle_membership.reload
+
+            expect(oldest_membership.contact_id).to eq(contact.id)
+            expect(oldest_membership.extra).to eq(extra_data)
+            expect(oldest_membership.custom_fields).to eq(custom_fields_data)
+
+            expect(middle_membership.contact_id).to eq(contact.id)
+            expect(middle_membership.extra).to eq(extra_data)
+            expect(middle_membership.custom_fields).to eq(custom_fields_data)
+          end
+
+          it "does not change the newest membership" do
+            newest_values = {
+              contact_id: newest_membership.contact_id,
+              extra: newest_membership.extra,
+              custom_fields: newest_membership.custom_fields
+            }
+
+            subject.perform_now
+            newest_membership.reload
+
+            expect(newest_membership.contact_id).to eq(newest_values[:contact_id])
+            expect(newest_membership.extra).to eq(newest_values[:extra])
+            expect(newest_membership.custom_fields).to eq(newest_values[:custom_fields])
+          end
+        end
+
+        context "when marked_for_deletion is set" do
+          let!(:older_membership) do
+            create(:civicrm_group_membership,
+                   group: group1,
+                   contact: nil,
+                   civicrm_contact_id: 100,
+                   marked_for_deletion: nil,
+                   updated_at: 2.days.ago)
+          end
+          let!(:newer_membership) do
+            create(:civicrm_group_membership,
+                   group: group2,
+                   contact:,
+                   civicrm_contact_id: 100,
+                   marked_for_deletion: Time.current,
+                   updated_at: 1.day.ago)
+          end
+
+          it "syncs the marked_for_deletion status" do
+            subject.perform_now
+            older_membership.reload
+
+            expect(older_membership.marked_for_deletion).not_to be_nil
+          end
+        end
+
+        context "when extra and custom_fields are empty in source" do
+          let!(:older_membership) do
+            create(:civicrm_group_membership,
+                   group: group1,
+                   contact: nil,
+                   civicrm_contact_id: 100,
+                   extra: old_extra_data,
+                   custom_fields: old_custom_fields_data,
+                   updated_at: 2.days.ago)
+          end
+          let!(:newer_membership) do
+            create(:civicrm_group_membership,
+                   group: group2,
+                   contact:,
+                   civicrm_contact_id: 100,
+                   extra: {},
+                   custom_fields: {},
+                   updated_at: 1.day.ago)
+          end
+
+          it "does not override with empty values" do
+            subject.perform_now
+            older_membership.reload
+
+            expect(older_membership.extra).to eq(old_extra_data)
+            expect(older_membership.custom_fields).to eq(old_custom_fields_data)
+          end
+
+          it "still syncs the contact_id" do
+            subject.perform_now
+            older_membership.reload
+
+            expect(older_membership.contact_id).to eq(contact.id)
+          end
+        end
+
+        context "with multiple sets of duplicates" do
+          let(:contact2) { create(:civicrm_contact, organization:, civicrm_contact_id: 200) }
+          let!(:membership_set1_old) do
+            create(:civicrm_group_membership,
+                   group: group1,
+                   contact: nil,
+                   civicrm_contact_id: 100,
+                   updated_at: 2.days.ago)
+          end
+          let!(:membership_set1_new) do
+            create(:civicrm_group_membership,
+                   group: group2,
+                   contact:,
+                   civicrm_contact_id: 100,
+                   updated_at: 1.day.ago)
+          end
+          let!(:membership_set2_old) do
+            create(:civicrm_group_membership,
+                   group: group1,
+                   contact: nil,
+                   civicrm_contact_id: 200,
+                   updated_at: 2.days.ago)
+          end
+          let!(:membership_set2_new) do
+            create(:civicrm_group_membership,
+                   group: group3,
+                   contact: contact2,
+                   civicrm_contact_id: 200,
+                   updated_at: 1.day.ago)
+          end
+
+          it "syncs both sets of duplicates independently" do
+            subject.perform_now
+
+            membership_set1_old.reload
+            membership_set2_old.reload
+
+            expect(membership_set1_old.contact_id).to eq(contact.id)
+            expect(membership_set2_old.contact_id).to eq(contact2.id)
+          end
+        end
+
+        context "when memberships have the same updated_at timestamp" do
+          let!(:membership1) do
+            create(:civicrm_group_membership,
+                   group: group1,
+                   contact: nil,
+                   civicrm_contact_id: 100,
+                   extra: old_extra_data,
+                   updated_at: 1.day.ago)
+          end
+          let!(:membership2) do
+            create(:civicrm_group_membership,
+                   group: group2,
+                   contact:,
+                   civicrm_contact_id: 100,
+                   extra: extra_data,
+                   updated_at: 1.day.ago)
+          end
+
+          it "uses the first one from the query as the source" do
+            # Should still complete without error
+            expect { subject.perform_now }.not_to raise_error
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/sync_group_members_job_spec.rb
+++ b/spec/jobs/sync_group_members_job_spec.rb
@@ -35,6 +35,11 @@ module Decidim::Civicrm
       expect(GroupMembership.pluck(:civicrm_contact_id)).to contain_exactly(17, 18, 23)
     end
 
+    it "schedules duplicate memberships sync job" do
+      subject.perform_now(group.id)
+      expect(SyncDuplicateGroupMembershipsJob).to have_been_enqueued
+    end
+
     it "preserves group title and description after sync" do
       group.update!(title: "Original Title", description: "Original Description")
 
@@ -124,7 +129,7 @@ module Decidim::Civicrm
       it "processes first page and schedules next page" do
         expect { subject.perform_now(group.id, page: 0) }.to change(GroupMembership, :count).by(1)
         expect(GroupMembership.pluck(:civicrm_contact_id)).to contain_exactly(17)
-        expect(subject).to have_been_enqueued.with(group.id, page: 1, sync_id: a_kind_of(ActiveSupport::TimeWithZone)).on_queue("default")
+        expect(subject).to have_been_enqueued.with(group.id, page: 1, sync_id: a_kind_of(ActiveSupport::TimeWithZone), skip_duplicate_sync: false).on_queue("default")
       end
     end
 
@@ -169,6 +174,13 @@ module Decidim::Civicrm
           expect(memberships[1].custom_fields).to eq({}) # Failed to fetch
           expect(memberships[2].custom_fields).not_to be_empty
         end
+      end
+    end
+
+    context "when skip_duplicate_sync is true" do
+      it "does not schedule duplicate memberships sync job" do
+        subject.perform_now(group.id, skip_duplicate_sync: true)
+        expect(SyncDuplicateGroupMembershipsJob).not_to have_been_enqueued
       end
     end
   end


### PR DESCRIPTION
## Overview

This PR adds functionality to synchronize data between group memberships that share the same `civicrm_contact_id`, keeping the data from the most recently updated record.

## Changes

### New Job
- **`SyncDuplicateGroupMembershipsJob`**: Synchronizes data between duplicate group memberships
  - Finds all `civicrm_contact_id` values with multiple memberships
  - Uses the most recently updated record as the source of truth
  - Syncs  `extra` and `custom_fields` fields
  - Includes comprehensive logging for tracking operations

### New Rake Task
- **`civicrm:sync:duplicate_memberships`**: Rake task to manually trigger the synchronization
  - Can be run with: \`bundle exec rake civicrm:sync:duplicate_memberships\`

### Job Integration
- **`SyncGroupMembersJob`**: Added \`skip_duplicate_sync\` parameter
  - Automatically calls duplicate sync at the end when syncing individual groups
  - Skips duplicate sync when called from \`SyncAllGroupsJob\` (to avoid redundant calls)
  
- **`SyncAllGroupsJob`**: Calls duplicate sync once at the end after all groups are synced

### Admin UI Improvements
- Added "Sync duplicate memberships" button in the groups admin interface
- **Route corrections**: Changed all sync-related routes from GET to POST (proper HTTP semantics for state-changing operations)
- **Toggle routes**: Changed toggle operations from PUT to POST (non-idempotent operations)
- Added sort functionality for the "members_civicrm" column in groups table

### Translations
- Added translations for the new sync action in English, Spanish, Catalan, and French

### Tests
- Comprehensive spec for \`SyncDuplicateGroupMembershipsJob\` with multiple scenarios:
  - No duplicates
  - Two and three duplicate memberships
  - Empty source data handling
  - Multiple sets of duplicates
  - Same timestamp edge cases
- Updated specs for \`SyncGroupMembersJob\` and \`SyncAllGroupsJob\` to handle the new duplicate sync integration

## Technical Details

The synchronization logic:
1. Identifies all \`civicrm_contact_id\` values that appear in multiple group memberships
2. Orders memberships by \`updated_at DESC\` to find the most recent
3. Copies data from the most recent to all older memberships
4. Only overwrites fields if source data is present (preserves existing data when source is empty)

This ensures data consistency across group memberships while respecting the temporal order of updates.