### PR TITLE
Add option to prevent revoting in CiViCRM census

### DIFF
--- a/app/forms/decidim/elections/admin/censuses/civicrm_groups_form.rb
+++ b/app/forms/decidim/elections/admin/censuses/civicrm_groups_form.rb
@@ -14,6 +14,7 @@ module Decidim
 
           attribute :civicrm_group_id, Integer
           attribute :verification_field_names, Array[String]
+          attribute :prevent_revoting, Decidim::AttributeObject::Model::Boolean, default: false
 
           validates :civicrm_group_id, presence: true
           validate :at_least_one_verification_field
@@ -41,7 +42,8 @@ module Decidim
           def census_settings
             {
               "civicrm_group_id" => civicrm_group_id,
-              "verification_fields" => valid_verification_field_names
+              "verification_fields" => valid_verification_field_names,
+              "prevent_revoting" => prevent_revoting
             }
           end
 
@@ -52,6 +54,13 @@ module Decidim
 
           def verification_field_names
             super.presence || verification_fields
+          end
+
+          # Override to fall back to persisted value when form attribute is not explicitly set
+          def prevent_revoting
+            return super if super
+
+            election&.census_settings&.dig("prevent_revoting") || false
           end
 
           private

--- a/app/forms/decidim/elections/admin/censuses/civicrm_groups_form.rb
+++ b/app/forms/decidim/elections/admin/censuses/civicrm_groups_form.rb
@@ -39,6 +39,18 @@ module Decidim
             Rails.cache.fetch(cache_key, expires_in: 1.hour) { fetch_custom_fields }
           end
 
+          # Returns options for the verification fields selector,
+          # with previously selected fields first (in saved order).
+          def ordered_custom_fields_options
+            all = available_custom_fields
+            selected = verification_field_names
+
+            selected_fields = selected.filter_map { |name| all.find { |f| f.name == name } }
+            unselected_fields = all.reject { |f| selected.include?(f.name) }
+
+            (selected_fields + unselected_fields).map { |f| [f.label, f.name] }
+          end
+
           def census_settings
             {
               "civicrm_group_id" => civicrm_group_id,

--- a/app/forms/decidim/elections/censuses/civicrm_groups_form.rb
+++ b/app/forms/decidim/elections/censuses/civicrm_groups_form.rb
@@ -15,6 +15,7 @@ module Decidim
 
         validate :verification_data_present
         validate :contact_in_census
+        validate :voter_has_not_voted
 
         def verification_data
           super&.with_indifferent_access || {}
@@ -123,6 +124,29 @@ module Decidim
             errors.add(:base, I18n.t("decidim.civicrm.censuses.civicrm_groups.field_required",
                                      field: humanize_field_name(field_name)))
           end
+        end
+
+        def voter_has_not_voted
+          return unless prevent_revoting?
+          return if errors.any?
+          return unless @civicrm_contact
+
+          uid = voter_uid
+          return if uid.blank?
+          return unless election_has_votes_for?(uid)
+
+          errors.add(:base, I18n.t("decidim.civicrm.censuses.civicrm_groups.already_voted"))
+        end
+
+        def prevent_revoting?
+          election&.census_settings&.dig("prevent_revoting") == true
+        end
+
+        def election_has_votes_for?(uid)
+          Decidim::Elections::Vote
+            .joins(:question)
+            .where(decidim_elections_questions: { election_id: election.id })
+            .exists?(voter_uid: uid)
         end
       end
     end

--- a/app/queries/decidim/civicrm/find_group_member_by_custom_fields.rb
+++ b/app/queries/decidim/civicrm/find_group_member_by_custom_fields.rb
@@ -16,7 +16,7 @@ module Decidim
         return GroupMembership.none if @group.blank? || @fields.blank?
 
         # Build conditions to check if each field key-value pair exists in custom_fields JSONB
-        conditions = @fields.map do |key, value|
+        conditions = @fields.map do |_key, _value|
           "custom_fields ->> ? = ?"
         end.join(" AND ")
 

--- a/app/queries/decidim/civicrm/find_group_member_by_custom_fields.rb
+++ b/app/queries/decidim/civicrm/find_group_member_by_custom_fields.rb
@@ -3,7 +3,7 @@
 module Decidim
   module Civicrm
     # Finds group memberships by matching custom field values within a specific group.
-    # Uses PostgreSQL JSONB containment operator (@>) for lookup.
+    # Checks if all provided field values match within the stored custom_fields JSONB.
     #
     # Returns an ActiveRecord relation of matching GroupMembership records.
     class FindGroupMemberByCustomFields < Decidim::Query
@@ -15,7 +15,12 @@ module Decidim
       def query
         return GroupMembership.none if @group.blank? || @fields.blank?
 
-        @group.group_memberships.where("custom_fields @> ?", @fields.to_json)
+        # Build conditions to check if each field key-value pair exists in custom_fields JSONB
+        conditions = @fields.map do |key, value|
+          "custom_fields ->> ? = ?"
+        end.join(" AND ")
+
+        @group.group_memberships.where(conditions, *@fields.flat_map { |k, v| [k, v] })
       end
     end
   end

--- a/app/views/decidim/elections/admin/censuses/_civicrm_groups_form.html.erb
+++ b/app/views/decidim/elections/admin/censuses/_civicrm_groups_form.html.erb
@@ -33,7 +33,7 @@
 </div>
 <div class="mt-4 mb-8 form__wrapper gap-1">
   <%= form.select :verification_field_names,
-                  form.object.available_custom_fields.map { |f| [f.label, f.name] },
+                  form.object.ordered_custom_fields_options,
                   { label: false },
                   multiple: true,
                   required: true,

--- a/app/views/decidim/elections/admin/censuses/_civicrm_groups_form.html.erb
+++ b/app/views/decidim/elections/admin/censuses/_civicrm_groups_form.html.erb
@@ -40,3 +40,9 @@
                   id: "civicrm-verification-fields-selector",
                   data: { multiselect: true } %>
 </div>
+
+<div class="mt-4 mb-8 form__wrapper gap-1">
+  <%= form.check_box :prevent_revoting,
+                     label: t("prevent_revoting", scope: "decidim.civicrm.censuses.civicrm_groups") %>
+  <p class="help-text"><%= t("prevent_revoting_help", scope: "decidim.civicrm.censuses.civicrm_groups") %></p>
+</div>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -269,15 +269,20 @@ ca:
         civicrm_groups:
           allowed_group: Grup del CiViCRM
           allowed_group_help: Selecciona el grup els membres del qual poden votar
+          already_voted: Ja heu votat en aquesta votació i no és possible canviar el vostre vot. Si creieu que es tracta d'una errada, contacteu amb suport.
           at_least_one_field: Almenys un camp de contacte ha de ser seleccionat
           custom_fields:
             Dades_comunes:
               Usuari_Decidim: DNI/NIE
             id: Contrasenya
+          duplicate_contact: S'ha trobat múltiples contactes. Si us plau, contacteu amb suport.
           field_required: "%{field} és requerit"
           invalid: Contacte no trobat al CiViCRM
+          last_sync_date: 'Dades del cens sincronitzades l''última vegada: %{date}'
           no_data: Si us plau, proporcioneu les dades de verificació necessàries
           not_in_group: El contacte no pertany al grup autoritzat
+          prevent_revoting: Evitar que els usuaris modifiquin els seus vots
+          prevent_revoting_help: Si està marcada, els votants que ja han votat no podran votar de nou ni canviar els seus vots.
           sync_warning: Tingueu en compte que el grup CiViCRM s'ha de sincronitzar per verificar els votants. Assegureu-vos que el grup estigui sincronitzat abans que comencin les eleccions.
           verification_fields: Camps de contacte que ha d'emplenar el votant
           verification_fields_help: Tingueu en compte que heu d'assegurar-vos que la combinació de camps escollida aquí sigui única per a cada usuari! En cas contrari, podríeu permetre que els usuaris anul·lin els vots dels altres.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -297,8 +297,8 @@ en:
         civicrm_groups:
           allowed_group: CiViCRM Group
           allowed_group_help: Select the group whose members can vote
-          already_voted: You have already voted in this election. Vote editing is
-            not allowed.
+          already_voted: You have already voted in this election and it is not possible
+            to change your vote. If you think this is a mistake, please contact support.
           at_least_one_field: At least one contact field must be selected
           custom_fields:
             Dades_comunes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -297,6 +297,8 @@ en:
         civicrm_groups:
           allowed_group: CiViCRM Group
           allowed_group_help: Select the group whose members can vote
+          already_voted: You have already voted in this election. Vote editing is
+            not allowed.
           at_least_one_field: At least one contact field must be selected
           custom_fields:
             Dades_comunes:
@@ -308,6 +310,9 @@ en:
           last_sync_date: 'Census data last synced: %{date}'
           no_data: Please provide the required verification data
           not_in_group: Contact does not belong to the authorized group
+          prevent_revoting: Prevent users from editing their votes
+          prevent_revoting_help: If checked, voters who have already cast their votes
+            will not be allowed to vote again or change their votes.
           sync_warning: Be aware that the CiViCRM group needs to be synchronized in
             order to verify voters. Make sure the group is synced before the election
             starts.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -269,15 +269,20 @@ es:
         civicrm_groups:
           allowed_group: Grupo CiViCRM
           allowed_group_help: Selecciona el grupo cuyos miembros pueden votar
+          already_voted: Ya ha votado en esta elección y no es posible cambiar su voto. Si cree que es un error, contacte con soporte.
           at_least_one_field: Debe seleccionar al menos un campo de contacto
           custom_fields:
             Dades_comunes:
               Usuari_Decidim: DNI/NIE
             id: Contraseña
+          duplicate_contact: Se encontraron múltiples contactos. Por favor, contacte con soporte.
           field_required: "%{field} es obligatorio"
           invalid: Contacto no encontrado en CiViCRM
+          last_sync_date: 'Datos del censo sincronizados por última vez: %{date}'
           no_data: Por favor proporcione los datos de verificación requeridos
           not_in_group: El contacto no pertenece al grupo autorizado
+          prevent_revoting: Evitar que los usuarios editen sus votos
+          prevent_revoting_help: Si está marcada, los votantes que ya han emitido su voto no podrán volver a votar ni cambiar sus votos.
           sync_warning: Tenga en cuenta que el grupo CiViCRM necesita sincronizarse para verificar los votantes. Asegúrese de que el grupo está sincronizado antes de que comience la elección.
           verification_fields: Campos de contacto requeridos para ser rellenados por el votante
           verification_fields_help: Tenga en cuenta que necesita asegurarse de que la combinación de campos elegidos aquí debe ser única por cada usuario. De lo contrario, podría permitir que los usuarios anulen los votos de otros.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -269,16 +269,21 @@ fr:
         civicrm_groups:
           allowed_group: Groupe CiViCRM
           allowed_group_help: Sélectionnez le groupe dont les membres peuvent voter
+          already_voted: Vous avez déjà voté à cette élection et il n'est pas possible de modifier votre vote. Si vous pensez que c'est une erreur, veuillez contacter l'assistance.
           at_least_one_field: Au moins un champ de contact doit être sélectionné
           custom_fields:
             Dades_comunes:
               Usuari_Decidim: Numéro de document
             id: Mot de passe
+          duplicate_contact: Plusieurs contacts ont été trouvés. Veuillez contacter l'assistance.
           field_required: "%{field} est obligatoire"
           invalid: Contact non trouvé dans CiViCRM
+          last_sync_date: 'Dernière synchronisation des données de recensement: %{date}'
           no_data: Veuillez fournir les données de vérification requises
           not_in_group: Le contact n'appartient pas au groupe autorisé
-          sync_warning: Notez que le groupe CiViCRM doit être synchronisé afin de vérifier les électeurs. Assurez-vous que le groupe est synchronisé avant le début de l'élection.
+          prevent_revoting: Empêcher les utilisateurs de modifier leurs votes
+          prevent_revoting_help: Si cette option est cochée, les électeurs qui ont déjà voté ne seront pas autorisés à voter à nouveau ou à modifier leurs votes.
+          sync_warning: Soyez conscient que le groupe CiViCRM doit être synchronisé afin de vérifier les électeurs. Assurez-vous que le groupe est synchronisé avant le début de l'élection.
           verification_fields: Champs de contact requis pour être remplis par l'électeur
           verification_fields_help: Notez que vous devez vous assurer que la combinaison de champs choisie ici doit être unique pour chaque utilisateur! Sinon, vous pourriez permettre aux utilisateurs d'annuler les votes d'autres.
       contact:

--- a/spec/forms/elections/admin/censuses/civicrm_groups_form_spec.rb
+++ b/spec/forms/elections/admin/censuses/civicrm_groups_form_spec.rb
@@ -196,6 +196,60 @@ module Decidim
 
               expect(settings["verification_fields"]).to eq(%w(Dades_comunes.Identificador_fiscal id Dades_comunes.Usuari_Decidim))
             end
+
+            context "when prevent_revoting is checked" do
+              let(:attributes) do
+                {
+                  civicrm_group_id: group1.civicrm_group_id,
+                  verification_field_names: ["Dades_comunes.Usuari_Decidim"],
+                  prevent_revoting: true
+                }
+              end
+
+              it "includes prevent_revoting as true in settings" do
+                expect(subject.census_settings["prevent_revoting"]).to be true
+              end
+            end
+
+            context "when prevent_revoting is unchecked" do
+              it "includes prevent_revoting as false in settings" do
+                expect(subject.census_settings["prevent_revoting"]).to be false
+              end
+            end
+          end
+
+          describe "#prevent_revoting" do
+            context "when attribute is set to true" do
+              let(:attributes) do
+                {
+                  civicrm_group_id: group1.civicrm_group_id,
+                  verification_field_names: ["Dades_comunes.Usuari_Decidim"],
+                  prevent_revoting: true
+                }
+              end
+
+              it "returns true" do
+                expect(subject.prevent_revoting).to be true
+              end
+            end
+
+            context "when attribute is not set" do
+              it "returns false by default" do
+                expect(subject.prevent_revoting).to be false
+              end
+            end
+
+            context "when attribute is not set but election has persisted value" do
+              let(:election) do
+                create(:election, component: component, census_settings: {
+                         "prevent_revoting" => true
+                       })
+              end
+
+              it "falls back to persisted census_settings value" do
+                expect(subject.prevent_revoting).to be true
+              end
+            end
           end
 
           describe "#verification_field_names" do

--- a/spec/forms/elections/admin/censuses/civicrm_groups_form_spec.rb
+++ b/spec/forms/elections/admin/censuses/civicrm_groups_form_spec.rb
@@ -252,6 +252,69 @@ module Decidim
             end
           end
 
+          describe "#ordered_custom_fields_options" do
+            it "returns all fields as [label, name] pairs" do
+              options = subject.ordered_custom_fields_options
+              expect(options).to be_a(Array)
+              expect(options.first).to be_a(Array)
+              expect(options.first.size).to eq(2)
+            end
+
+            context "when no fields are selected" do
+              let(:attributes) { { civicrm_group_id: group1.civicrm_group_id, verification_field_names: [] } }
+
+              it "returns fields in API order" do
+                options = subject.ordered_custom_fields_options
+                api_order = subject.available_custom_fields.map { |f| [f.label, f.name] }
+                expect(options).to eq(api_order)
+              end
+            end
+
+            context "when fields are selected in a different order than API" do
+              let(:attributes) do
+                {
+                  civicrm_group_id: group1.civicrm_group_id,
+                  verification_field_names: %w(Dades_comunes.Usuari_Decidim id)
+                }
+              end
+
+              it "places selected fields first in saved order" do
+                options = subject.ordered_custom_fields_options
+                names = options.map(&:last)
+
+                expect(names[0]).to eq("Dades_comunes.Usuari_Decidim")
+                expect(names[1]).to eq("id")
+              end
+
+              it "places unselected fields after selected ones" do
+                options = subject.ordered_custom_fields_options
+                names = options.map(&:last)
+
+                selected = %w(Dades_comunes.Usuari_Decidim id)
+                unselected_start = names.index { |n| !selected.include?(n) }
+                expect(unselected_start).to eq(2)
+              end
+            end
+
+            context "when loading from persisted census_settings" do
+              let(:attributes) { { civicrm_group_id: group1.civicrm_group_id, verification_field_names: [] } }
+              let(:election) do
+                create(:election, component: component, census_settings: {
+                         "civicrm_group_id" => group1.civicrm_group_id,
+                         "verification_fields" => %w(Dades_comunes.Usuari_Decidim id)
+                       })
+              end
+
+              it "preserves the persisted order" do
+                options = subject.ordered_custom_fields_options
+                names = options.map(&:last)
+
+                expect(names[0]).to eq("Dades_comunes.Usuari_Decidim")
+                expect(names[1]).to eq("id")
+              end
+            end
+          end
+
           describe "#verification_field_names" do
             context "when attribute is set" do
               let(:attributes) { { verification_field_names: ["custom_field"] } }

--- a/spec/forms/elections/admin/censuses/civicrm_groups_form_spec.rb
+++ b/spec/forms/elections/admin/censuses/civicrm_groups_form_spec.rb
@@ -291,7 +291,7 @@ module Decidim
                 names = options.map(&:last)
 
                 selected = %w(Dades_comunes.Usuari_Decidim id)
-                unselected_start = names.index { |n| !selected.include?(n) }
+                unselected_start = names.index { |n| selected.exclude?(n) }
                 expect(unselected_start).to eq(2)
               end
             end

--- a/spec/forms/elections/censuses/civicrm_groups_form_spec.rb
+++ b/spec/forms/elections/censuses/civicrm_groups_form_spec.rb
@@ -244,6 +244,97 @@ module Decidim
           end
         end
 
+        describe "revoting prevention" do
+          let(:expected_voter_uid) do
+            Digest::SHA512.hexdigest(
+              "civicrm-#{contact_id}-#{election.id}-#{Rails.application.secret_key_base}"
+            )
+          end
+
+          context "when prevent_revoting is enabled" do
+            let(:census_settings) do
+              {
+                "civicrm_group_id" => group.civicrm_group_id,
+                "verification_fields" => ["Dades_comunes.Usuari_Decidim"],
+                "prevent_revoting" => true
+              }
+            end
+
+            context "and voter has not voted yet" do
+              it { is_expected.to be_valid }
+            end
+
+            context "and voter has already voted" do
+              let!(:election_question) do
+                create(:election_question, :with_response_options, :voting_enabled, election: election)
+              end
+
+              let!(:existing_vote) do
+                create(:election_vote,
+                       question: election_question,
+                       response_option: election_question.response_options.first,
+                       voter_uid: expected_voter_uid)
+              end
+
+              it { is_expected.not_to be_valid }
+
+              it "adds already_voted error" do
+                subject.valid?
+
+                expect(subject.errors[:base]).to include(
+                  I18n.t("decidim.civicrm.censuses.civicrm_groups.already_voted")
+                )
+              end
+            end
+          end
+
+          context "when prevent_revoting is disabled (default)" do
+            let!(:election_question) do
+              create(:election_question, :with_response_options, :voting_enabled, election: election)
+            end
+
+            let!(:existing_vote) do
+              create(:election_vote,
+                     question: election_question,
+                     response_option: election_question.response_options.first,
+                     voter_uid: expected_voter_uid)
+            end
+
+            it { is_expected.to be_valid }
+
+            it "does not add already_voted error" do
+              subject.valid?
+
+              expect(subject.errors[:base]).not_to include(
+                I18n.t("decidim.civicrm.censuses.civicrm_groups.already_voted")
+              )
+            end
+          end
+
+          context "when prevent_revoting is explicitly set to false" do
+            let(:census_settings) do
+              {
+                "civicrm_group_id" => group.civicrm_group_id,
+                "verification_fields" => ["Dades_comunes.Usuari_Decidim"],
+                "prevent_revoting" => false
+              }
+            end
+
+            let!(:election_question) do
+              create(:election_question, :with_response_options, :voting_enabled, election: election)
+            end
+
+            let!(:existing_vote) do
+              create(:election_vote,
+                     question: election_question,
+                     response_option: election_question.response_options.first,
+                     voter_uid: expected_voter_uid)
+            end
+
+            it { is_expected.to be_valid }
+          end
+        end
+
         describe "#civicrm_group_id" do
           it "returns group id from census_settings" do
             expect(subject.civicrm_group_id).to eq(group.civicrm_group_id)

--- a/spec/system/admin_elections_civicrm_census_spec.rb
+++ b/spec/system/admin_elections_civicrm_census_spec.rb
@@ -76,6 +76,15 @@ describe "Admin Elections CiViCRM Groups Census configuration" do
         end
       end
 
+      it "shows the prevent revoting checkbox" do
+        expect(page).to have_css(".census-form", wait: 2)
+
+        within ".census-form" do
+          expect(page).to have_field("civicrm_groups_prevent_revoting", type: "checkbox")
+          expect(page).to have_content("Prevent users from editing their votes")
+        end
+      end
+
       it "shows all available custom fields from API in the multiselect" do
         expect(page).to have_css(".census-form", wait: 2)
 
@@ -128,6 +137,27 @@ describe "Admin Elections CiViCRM Groups Census configuration" do
 
     it "shows the total census count" do
       expect(page).to have_content("There are currently 2 people eligible for voting")
+    end
+  end
+
+  describe "census with prevent_revoting persisted" do
+    let(:census_settings) do
+      {
+        "civicrm_group_id" => group1.civicrm_group_id,
+        "verification_fields" => ["Dades_comunes.Usuari_Decidim"],
+        "prevent_revoting" => true
+      }
+    end
+
+    before do
+      election.update!(census_manifest: "civicrm_groups", census_settings: census_settings)
+      visit Decidim::EngineRouter.admin_proxy(elections_component).census_election_path(election)
+    end
+
+    it "shows the prevent revoting checkbox as checked" do
+      within ".census-form" do
+        expect(page).to have_checked_field("civicrm_groups_prevent_revoting")
+      end
     end
   end
 

--- a/spec/system/admin_elections_civicrm_census_spec.rb
+++ b/spec/system/admin_elections_civicrm_census_spec.rb
@@ -161,6 +161,45 @@ describe "Admin Elections CiViCRM Groups Census configuration" do
     end
   end
 
+  describe "verification fields order is preserved after save" do
+    let(:census_settings) do
+      {
+        "civicrm_group_id" => group1.civicrm_group_id,
+        "verification_fields" => %w(Dades_comunes.Usuari_Decidim id)
+      }
+    end
+
+    before do
+      election.update!(census_manifest: "civicrm_groups", census_settings: census_settings)
+    end
+
+    it "shows selected fields in saved order when reopening the form" do
+      visit Decidim::EngineRouter.admin_proxy(elections_component).census_election_path(election)
+      expect(page).to have_css(".census-form", wait: 2)
+
+      within ".census-form" do
+        items = all("#civicrm-verification-fields-selector + .ts-wrapper .ts-control .item")
+        item_texts = items.map(&:text)
+
+        expect(item_texts[0]).to include("Dades_comunes.Usuari_Decidim")
+        expect(item_texts[1]).to include("id")
+      end
+
+      election.update!(census_settings: census_settings.merge("verification_fields" => %w(id Dades_comunes.Usuari_Decidim)))
+
+      visit Decidim::EngineRouter.admin_proxy(elections_component).census_election_path(election)
+      expect(page).to have_css(".census-form", wait: 2)
+
+      within ".census-form" do
+        items = all("#civicrm-verification-fields-selector + .ts-wrapper .ts-control .item")
+        item_texts = items.map(&:text)
+
+        expect(item_texts[0]).to include("id")
+        expect(item_texts[1]).to include("Dades_comunes.Usuari_Decidim")
+      end
+    end
+  end
+
   describe "census preview includes members without Decidim accounts" do
     let!(:contact) { create(:civicrm_contact, organization:) }
     let!(:membership_with_account) { create(:civicrm_group_membership, contact:, group: group1) }

--- a/spec/system/elections_civicrm_census_spec.rb
+++ b/spec/system/elections_civicrm_census_spec.rb
@@ -92,6 +92,69 @@ describe "Elections CiViCRM Groups Census voting" do
       end
     end
 
+    context "when prevent_revoting is enabled and user has already voted" do
+      let(:data) { JSON.parse(file_fixture("v4/find_contact_by_fields_valid_response.json").read) }
+
+      let(:census_settings) do
+        {
+          "civicrm_group_id" => group.civicrm_group_id,
+          "verification_fields" => ["user_id"],
+          "prevent_revoting" => true
+        }
+      end
+
+      let!(:membership) { create(:civicrm_group_membership, group:, contact: nil, civicrm_contact_id: 123) }
+
+      let(:voter_uid) do
+        Digest::SHA512.hexdigest(
+          "civicrm-123-#{election.id}-#{Rails.application.secret_key_base}"
+        )
+      end
+
+      let!(:existing_vote) do
+        create(:election_vote,
+               question:,
+               response_option: question.response_options.first,
+               voter_uid:)
+      end
+
+      it "shows already voted error" do
+        visit Decidim::EngineRouter.main_proxy(elections_component).new_election_vote_path(election)
+
+        fill_in "user id", with: "user_001"
+        click_on "Access"
+
+        expect(page).to have_content("You have already voted in this election")
+      end
+    end
+
+    context "when prevent_revoting is disabled and user has already voted" do
+      let(:data) { JSON.parse(file_fixture("v4/find_contact_by_fields_valid_response.json").read) }
+      let!(:membership) { create(:civicrm_group_membership, group:, contact: nil, civicrm_contact_id: 123) }
+
+      let(:voter_uid) do
+        Digest::SHA512.hexdigest(
+          "civicrm-123-#{election.id}-#{Rails.application.secret_key_base}"
+        )
+      end
+
+      let!(:existing_vote) do
+        create(:election_vote,
+               question:,
+               response_option: question.response_options.first,
+               voter_uid:)
+      end
+
+      it "allows access to voting" do
+        visit Decidim::EngineRouter.main_proxy(elections_component).new_election_vote_path(election)
+
+        fill_in "user id", with: "user_001"
+        click_on "Access"
+
+        expect(page).to have_content(translated(question.body))
+      end
+    end
+
     context "when user fills all fields but contact is not found" do
       let(:census_settings) do
         {


### PR DESCRIPTION
Adds a "Prevent users from editing their votes" checkbox to the CiViCRM Groups census admin configuration. When enabled, voters who have already cast their votes are denied access to the voting booth.  

Fixes #35  