### PR TITLE
Fix multi-tenant census mix

### DIFF
--- a/app/forms/decidim/elections/censuses/civicrm_groups_form.rb
+++ b/app/forms/decidim/elections/censuses/civicrm_groups_form.rb
@@ -83,7 +83,10 @@ module Decidim
         end
 
         def find_contact_by_fields(fields)
-          Decidim::Civicrm::Api::V4::FindContactByFields.new(fields).result
+          group = find_census_group
+          group_ids = group.present? ? [group.civicrm_group_id] : []
+
+          Decidim::Civicrm::Api::V4::FindContactByFields.new(fields, group_ids).result
         rescue StandardError => e
           Rails.logger.error("CiviCRM census search error: #{e.message}")
           nil

--- a/app/forms/decidim/elections/censuses/civicrm_groups_form.rb
+++ b/app/forms/decidim/elections/censuses/civicrm_groups_form.rb
@@ -84,9 +84,9 @@ module Decidim
 
         def find_contact_by_fields(fields)
           group = find_census_group
-          group_ids = group.present? ? [group.civicrm_group_id] : []
+          return nil unless group&.civicrm_group_id.present?
 
-          Decidim::Civicrm::Api::V4::FindContactByFields.new(fields, group_ids).result
+          Decidim::Civicrm::Api::V4::FindContactByFields.new(fields, [group.civicrm_group_id]).result
         rescue StandardError => e
           Rails.logger.error("CiviCRM census search error: #{e.message}")
           nil

--- a/app/forms/decidim/elections/censuses/civicrm_groups_form.rb
+++ b/app/forms/decidim/elections/censuses/civicrm_groups_form.rb
@@ -84,7 +84,7 @@ module Decidim
 
         def find_contact_by_fields(fields)
           group = find_census_group
-          return nil unless group&.civicrm_group_id.present?
+          return nil if group&.civicrm_group_id.blank?
 
           Decidim::Civicrm::Api::V4::FindContactByFields.new(fields, [group.civicrm_group_id]).result
         rescue StandardError => e

--- a/lib/decidim/civicrm/engine.rb
+++ b/lib/decidim/civicrm/engine.rb
@@ -157,7 +157,7 @@ module Decidim
             group_id = election.census_settings&.dig("civicrm_group_id")
             next Decidim::Civicrm::GroupMembership.none unless group_id
 
-            group = Decidim::Civicrm::Group.find_by(civicrm_group_id: group_id)
+            group = Decidim::Civicrm::Group.find_by(civicrm_group_id: group_id, organization: election.organization)
             next Decidim::Civicrm::GroupMembership.none unless group
 
             group.group_memberships

--- a/spec/forms/elections/censuses/civicrm_groups_form_spec.rb
+++ b/spec/forms/elections/censuses/civicrm_groups_form_spec.rb
@@ -138,6 +138,11 @@ module Decidim
             end
 
             it "falls back to API and succeeds" do
+              expect(Decidim::Civicrm::Api::V4::FindContactByFields)
+                .to receive(:new)
+                .with({ "Dades_comunes.Usuari_Decidim" => "user_001" }, [group.civicrm_group_id])
+                .and_call_original
+
               expect(subject).to be_valid
             end
           end
@@ -152,6 +157,11 @@ module Decidim
             end
 
             it "falls back to API and succeeds" do
+              expect(Decidim::Civicrm::Api::V4::FindContactByFields)
+                .to receive(:new)
+                .with({ "Dades_comunes.Usuari_Decidim" => "user_001" }, [group.civicrm_group_id])
+                .and_call_original
+
               expect(subject).to be_valid
             end
           end

--- a/spec/lib/decidim/civicrm/group_membership_census_spec.rb
+++ b/spec/lib/decidim/civicrm/group_membership_census_spec.rb
@@ -81,6 +81,28 @@ module Decidim
         end
       end
 
+      context "when another organization has the same civicrm_group_id" do
+        let!(:other_organization) { create(:organization) }
+        let!(:other_process) { create(:participatory_process, organization: other_organization) }
+        let!(:other_component) { create(:elections_component, participatory_space: other_process) }
+        let!(:other_group_same_external_id) do
+          create(:civicrm_group, organization: other_organization, civicrm_group_id: group.civicrm_group_id)
+        end
+        let!(:membership_in_current_org_group) do
+          create(:civicrm_group_membership, group: group, contact: nil, civicrm_contact_id: 4101)
+        end
+        let!(:membership_in_other_org_group) do
+          create(:civicrm_group_membership, group: other_group_same_external_id, contact: nil, civicrm_contact_id: 4102)
+        end
+
+        it "only includes memberships from the election organization" do
+          result = manifest.users(election, 0, 100)
+
+          expect(result).to include(membership_in_current_org_group)
+          expect(result).not_to include(membership_in_other_org_group)
+        end
+      end
+
       context "when no group_id is configured" do
         let(:census_settings) { {} }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved census contact verification by restricting external contact searches to the relevant CiviCRM group.
  * Ensured verification continues correctly when local membership details are missing or do not match.

* **Tests**
  * Added coverage confirming that contact lookups use the configured verification fields and authorized group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->